### PR TITLE
fix: comment out mobile hamburger menu

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @next/next/no-img-element */
 import { Fragment, ReactElement } from 'react'
-import { Disclosure, Menu, Transition } from '@headlessui/react'
-import { DotsVerticalIcon, MenuIcon, XIcon } from '@heroicons/react/outline'
+import { Menu, Transition } from '@headlessui/react'
+import { DotsVerticalIcon } from '@heroicons/react/outline'
 import { ellipseAddress } from '../lib/utilities'
 import { useState } from 'react'
 import { useRouter } from 'next/router'
@@ -44,16 +44,16 @@ export default function Navigation({
   const router = useRouter()
   return (
     <>
-      <Disclosure
+      {/* <Disclosure
         as="nav"
         className="bg-transparent border-b-2 border-white border-opacity-10"
       >
-        {({ open }) => (
-          <>
-            <div className="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8">
-              <div className="relative flex items-center justify-between h-16">
-                <div className="absolute inset-y-0 left-0 flex items-center sm:hidden">
-                  {/* Mobile menu button*/}
+        {({ open }) => ( */}
+      <>
+        <div className="max-w-7xl mx-auto px-2 sm:px-6 lg:px-8">
+          <div className="relative flex items-center justify-between h-16">
+            {/* Mobile menu button*/}
+            {/* <div className="absolute inset-y-0 left-0 flex items-center sm:hidden">
                   <Disclosure.Button className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
                     <span className="sr-only">Open main menu</span>
                     {open ? (
@@ -62,73 +62,73 @@ export default function Navigation({
                       <MenuIcon className="block h-6 w-6" aria-hidden="true" />
                     )}
                   </Disclosure.Button>
-                </div>
-                <div className="flex">
-                  <Link href="/">
-                    <a className="flex">
-                      <div className="flex-shrink-0">
-                        <svg
-                          className="w-8 h-8 mr-2 ml-12 sm:ml-0"
-                          width="64"
-                          height="64"
-                          viewBox="0 0 64 64"
-                          fill="none"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M0.403013 37.3991L26.6009 63.597C13.2225 61.3356 2.66442 50.7775 0.403013 37.3991Z"
-                            fill="#fff"
-                          ></path>
-                          <path
-                            d="M0 30.2868L33.7132 64C35.7182 63.8929 37.6742 63.6013 39.5645 63.142L0.85799 24.4355C0.398679 26.3259 0.10713 28.2818 0 30.2868Z"
-                            fill="#fff"
-                          ></path>
-                          <path
-                            d="M2.53593 19.4042L44.5958 61.4641C46.1277 60.8066 47.598 60.0331 48.9956 59.1546L4.84543 15.0044C3.96691 16.402 3.19339 17.8723 2.53593 19.4042Z"
-                            fill="#fff"
-                          ></path>
-                          <path
-                            d="M7.69501 11.1447C13.5677 4.32093 22.2677 0 31.9769 0C49.6628 0 64 14.3372 64 32.0231C64 41.7323 59.6791 50.4323 52.8553 56.305L7.69501 11.1447Z"
-                            fill="#fff"
-                          ></path>
-                        </svg>
-                      </div>
-                      <div className="flex-shrink-0 hidden md:block">
-                        <h1 className="text-xl font-bold text-white leading-none">
-                          DeFi Recommendation Portal
-                        </h1>
-                        <h2 className="text-xs font-medium text-white text-opacity-70 leading-none">
-                          DeFi recommendations from your social circle
-                          {/* Powered by UTU Trust Engine */}
-                        </h2>
-                      </div>
-                    </a>
-                  </Link>
-
-                  <div className="hidden sm:block sm:ml-6">
-                    <div className="flex space-x-4">
-                      {navigation.map((item) => (
-                        <Link key={item.name} href={item.href}>
-                          <a
-                            className={classNames(
-                              item.href === router.pathname
-                                ? 'bg-gray-900 text-white'
-                                : 'text-gray-300 hover:bg-gray-700 hover:text-white',
-                              'px-3 py-2 rounded-md text-sm font-medium'
-                            )}
-                            aria-current={
-                              item.href === router.pathname ? 'page' : undefined
-                            }
-                          >
-                            {item.name}
-                          </a>
-                        </Link>
-                      ))}
-                    </div>
+                </div> */}
+            <div className="flex">
+              <Link href="/">
+                <a className="flex">
+                  <div className="flex-shrink-0">
+                    <svg
+                      className="w-8 h-8 mr-2 ml-12 sm:ml-0"
+                      width="64"
+                      height="64"
+                      viewBox="0 0 64 64"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M0.403013 37.3991L26.6009 63.597C13.2225 61.3356 2.66442 50.7775 0.403013 37.3991Z"
+                        fill="#fff"
+                      ></path>
+                      <path
+                        d="M0 30.2868L33.7132 64C35.7182 63.8929 37.6742 63.6013 39.5645 63.142L0.85799 24.4355C0.398679 26.3259 0.10713 28.2818 0 30.2868Z"
+                        fill="#fff"
+                      ></path>
+                      <path
+                        d="M2.53593 19.4042L44.5958 61.4641C46.1277 60.8066 47.598 60.0331 48.9956 59.1546L4.84543 15.0044C3.96691 16.402 3.19339 17.8723 2.53593 19.4042Z"
+                        fill="#fff"
+                      ></path>
+                      <path
+                        d="M7.69501 11.1447C13.5677 4.32093 22.2677 0 31.9769 0C49.6628 0 64 14.3372 64 32.0231C64 41.7323 59.6791 50.4323 52.8553 56.305L7.69501 11.1447Z"
+                        fill="#fff"
+                      ></path>
+                    </svg>
                   </div>
-                </div>
+                  <div className="flex-shrink-0 hidden md:block">
+                    <h1 className="text-xl font-bold text-white leading-none">
+                      DeFi Recommendation Portal
+                    </h1>
+                    <h2 className="text-xs font-medium text-white text-opacity-70 leading-none">
+                      DeFi recommendations from your social circle
+                      {/* Powered by UTU Trust Engine */}
+                    </h2>
+                  </div>
+                </a>
+              </Link>
 
-                {/* <div className="flex-1 flex items-center justify-center sm:items-stretch sm:justify-start">
+              <div className="block">
+                <div className="flex space-x-4 ml-5">
+                  {navigation.map((item) => (
+                    <Link key={item.name} href={item.href}>
+                      <a
+                        className={classNames(
+                          item.href === router.pathname
+                            ? 'bg-gray-900 text-white'
+                            : 'text-gray-300 hover:bg-gray-700 hover:text-white',
+                          'px-3 py-2 rounded-md text-sm font-medium'
+                        )}
+                        aria-current={
+                          item.href === router.pathname ? 'page' : undefined
+                        }
+                      >
+                        {item.name}
+                      </a>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* <div className="flex-1 flex items-center justify-center sm:items-stretch sm:justify-start">
                   <div className="flex-shrink-0 flex items-center">
                     <img
                       className="block lg:hidden h-8 w-auto"
@@ -142,19 +142,19 @@ export default function Navigation({
                     />
                   </div>
                 </div> */}
-                <div className="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
-                  {/* Profile dropdown */}
-                  {address && (
-                    <div className="grid">
-                      <div>
-                        {/* <p className="mb-1">Address:</p> */}
-                        <p className=" rounded-full hidden md:block px-2 py-1 bg-gray-900 text-white text-xs bg-opacity-50 text-opacity-90 mx-2">
-                          {ellipseAddress(address)}
-                        </p>
-                      </div>
-                    </div>
-                  )}
-                  {/* {address && (
+            <div className="absolute inset-y-0 right-0 flex items-center pr-2 sm:static sm:inset-auto sm:ml-6 sm:pr-0">
+              {/* Profile dropdown */}
+              {address && (
+                <div className="grid">
+                  <div>
+                    {/* <p className="mb-1">Address:</p> */}
+                    <p className=" rounded-full hidden md:block px-2 py-1 bg-gray-900 text-white text-xs bg-opacity-50 text-opacity-90 mx-2">
+                      {ellipseAddress(address)}
+                    </p>
+                  </div>
+                </div>
+              )}
+              {/* {address && (
           <div className="grid">
             <div>
               <p className=" rounded-full px-2 py-1 bg-gray-900 text-white bg-opacity-50 text-opacity-90 w-24 hover:w-full truncate overflow-ellipsis overflow-hidden">{address}</p>
@@ -162,104 +162,101 @@ export default function Navigation({
           </div>
         )} */}
 
-                  {!address && !web3p && !web3Provider && (
-                    <button
-                      className="w-full border-white border-2 space-x-3 flex-row flex justify-between  rounded-md shadow pr-3 py-2 bg-transparent text-white font-mediumnhover:bg-white hover:bg-white hover:text-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm"
-                      //  className="rounded-full bg-green-400 px-3 py-2 text-white hover:bg-green-500"
-                      type="button"
-                      onClick={() => setIsConnectOpen(true)}
-                    >
-                      <p>
-                        <LoginIcon
-                          className="h-6 w-6 ml-3"
-                          aria-hidden="true"
-                        />
-                      </p>
-                      <p className="mt-0.5">CONNECT</p>
-                    </button>
-                  )}
-                  {address && <UserAvatar address={address} size={32} />}
+              {!address && !web3p && !web3Provider && (
+                <button
+                  className="w-full border-white border-2 space-x-3 flex-row flex justify-between  rounded-md shadow pr-3 py-2 bg-transparent text-white font-mediumnhover:bg-white hover:bg-white hover:text-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm"
+                  //  className="rounded-full bg-green-400 px-3 py-2 text-white hover:bg-green-500"
+                  type="button"
+                  onClick={() => setIsConnectOpen(true)}
+                >
+                  <p>
+                    <LoginIcon className="h-6 w-6 ml-3" aria-hidden="true" />
+                  </p>
+                  <p className="mt-0.5">CONNECT</p>
+                </button>
+              )}
+              {address && <UserAvatar address={address} size={32} />}
 
-                  {address && (
-                    <Menu as="div" className="relative">
-                      <div>
-                        <Menu.Button className="ml-3 bg-transparent p-1 rounded-full text-white hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white">
-                          <span className="sr-only">Open user menu</span>
-                          <span className="sr-only">View notifications</span>
+              {address && (
+                <Menu as="div" className="relative">
+                  <div>
+                    <Menu.Button className="ml-3 bg-transparent p-1 rounded-full text-white hover:text-blue-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-white">
+                      <span className="sr-only">Open user menu</span>
+                      <span className="sr-only">View notifications</span>
 
-                          <DotsVerticalIcon
-                            className="h-6 w-6"
-                            aria-hidden="true"
-                          />
-                        </Menu.Button>
-                      </div>
-                      <Transition
-                        as={Fragment}
-                        enter="transition ease-out duration-100"
-                        enterFrom="transform opacity-0 scale-95"
-                        enterTo="transform opacity-100 scale-100"
-                        leave="transition ease-in duration-75"
-                        leaveFrom="transform opacity-100 scale-100"
-                        leaveTo="transform opacity-0 scale-95"
-                      >
-                        <Menu.Items className="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
-                          <Menu.Item>
-                            {({ active }) => (
-                              <div
-                                className={classNames(
-                                  active ? 'bg-gray-100' : '',
-                                  'px-4 py-1 mt-1 text-sm  bg-gray-50 text-gray-700 text-right flex flex-row space-x-2'
-                                )}
-                              >
-                                <StatusOnlineIcon
-                                  className="h-6 w-6 text-green-500"
-                                  aria-hidden="true"
-                                />
-                                <p className="mt-0.5 font-medium text-gray-500">
-                                  {chainData?.name}
-                                </p>
-                              </div>
+                      <DotsVerticalIcon
+                        className="h-6 w-6"
+                        aria-hidden="true"
+                      />
+                    </Menu.Button>
+                  </div>
+                  <Transition
+                    as={Fragment}
+                    enter="transition ease-out duration-100"
+                    enterFrom="transform opacity-0 scale-95"
+                    enterTo="transform opacity-100 scale-100"
+                    leave="transition ease-in duration-75"
+                    leaveFrom="transform opacity-100 scale-100"
+                    leaveTo="transform opacity-0 scale-95"
+                  >
+                    <Menu.Items className="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+                      <Menu.Item>
+                        {({ active }) => (
+                          <div
+                            className={classNames(
+                              active ? 'bg-gray-100' : '',
+                              'px-4 py-1 mt-1 text-sm  bg-gray-50 text-gray-700 text-right flex flex-row space-x-2'
                             )}
-                          </Menu.Item>
-                          <Menu.Item>
-                            {({ active }) => (
-                              <a
-                                href="#"
-                                className={classNames(
-                                  active ? 'bg-gray-100' : '',
-                                  'block px-4 py-2 text-sm text-gray-700'
-                                )}
-                              >
-                                Settings
-                              </a>
+                          >
+                            <StatusOnlineIcon
+                              className="h-6 w-6 text-green-500"
+                              aria-hidden="true"
+                            />
+                            <p className="mt-0.5 font-medium text-gray-500">
+                              {chainData?.name}
+                            </p>
+                          </div>
+                        )}
+                      </Menu.Item>
+                      <Menu.Item>
+                        {({ active }) => (
+                          <a
+                            href="#"
+                            className={classNames(
+                              active ? 'bg-gray-100' : '',
+                              'block px-4 py-2 text-sm text-gray-700'
                             )}
-                          </Menu.Item>
-                          <Menu.Item>
-                            {({ active }) => (
-                              <a
-                                onClick={disconnect}
-                                className={classNames(
-                                  active ? 'bg-red-100 text-red-500 ' : '',
-                                  'justify-between flex flex-row whitespace-nowrap px-4 py-2 text-sm text-gray-700'
-                                )}
-                              >
-                                Disconnect wallet
-                                <LogoutIcon
-                                  className="h-5 w-5"
-                                  aria-hidden="true"
-                                />
-                              </a>
+                          >
+                            Settings
+                          </a>
+                        )}
+                      </Menu.Item>
+                      <Menu.Item>
+                        {({ active }) => (
+                          <a
+                            onClick={disconnect}
+                            className={classNames(
+                              active ? 'bg-red-100 text-red-500 ' : '',
+                              'justify-between flex flex-row whitespace-nowrap px-4 py-2 text-sm text-gray-700'
                             )}
-                          </Menu.Item>
-                        </Menu.Items>
-                      </Transition>
-                    </Menu>
-                  )}
-                </div>
-              </div>
+                          >
+                            Disconnect wallet
+                            <LogoutIcon
+                              className="h-5 w-5"
+                              aria-hidden="true"
+                            />
+                          </a>
+                        )}
+                      </Menu.Item>
+                    </Menu.Items>
+                  </Transition>
+                </Menu>
+              )}
             </div>
+          </div>
+        </div>
 
-            <Disclosure.Panel className="sm:hidden">
+        {/* <Disclosure.Panel className="sm:hidden">
               <div className="px-2 pt-2 pb-3 space-y-1">
                 {navigation.map((item) => (
                   <Link key={item.name} href={item.href}>
@@ -279,10 +276,10 @@ export default function Navigation({
                   </Link>
                 ))}
               </div>
-            </Disclosure.Panel>
-          </>
-        )}
-      </Disclosure>
+            </Disclosure.Panel> */}
+      </>
+      {/* )}
+      </Disclosure> */}
       {!address && isConnectOpen && (
         <ConnectModal
           connect={connect}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import Layout from '../components/Layout'
 
 import { connect, storeAddress } from '../redux/actions/wallet.actions'
+// import Link from 'next/link'
 
 export const Home = (): ReactElement => {
   const dispatch = useDispatch()
@@ -27,12 +28,20 @@ export const Home = (): ReactElement => {
     setEthAddress(e.target.value)
   }
 
+  // const navigation = [
+  //   { name: 'DeFi', href: '/defi' },
+  //   { name: 'Ocean', href: '/ocean' },
+  // ]
+
+  // function classNames(...classes) {
+  //   return classes.filter(Boolean).join(' ')
+  // }
   return (
     <Layout
     // title="Tailored DeFi recommendations"
     // subtitle="From the people you trust."
     >
-      <div className="max-w-screen-lg mx-5 pt-44 mt-2">
+      <div className="max-w-screen-lg mx-auto px-5 pt-44 mt-2">
         <h2 className="text-3xl leading-9 font-extrabold tracking-tight text-white sm:text-4xl sm:leading-10">
           Tailored DeFi recommendations
           <br />
@@ -82,6 +91,25 @@ export const Home = (): ReactElement => {
             <p className="text-red-500 text-sm mt-1">{errorMsg && errorMsg}</p>
           </>
         )}
+        {/* {address && (
+          <div className="flex py-10 space-x-4">
+            {navigation.map((item) => (
+              <Link key={item.name} href={item.href}>
+                <a
+                  className={classNames(
+                    'bg-primary text-white hover:bg-gray-700 hover:text-white',
+                    'px-3 py-2 rounded-md text-sm font-medium'
+                  )}
+                  aria-current={
+                    item.href === router.pathname ? 'page' : undefined
+                  }
+                >
+                  {item.name}
+                </a>
+              </Link>
+            ))}
+          </div>
+        )} */}
       </div>
     </Layout>
   )


### PR DESCRIPTION
We don't need hamburger menu on mobile for now, and introduces a bug on homepage when open the title (which is white, gets displaced to the white background and is not visible.

Also added, but commented out, adding defi/ocean buttons on homepage after the CTA once you're loggedIn, in case you miss the navigation on top.